### PR TITLE
Do not allocate intermediate byte[] array when encoding to Stream with config

### DIFF
--- a/src/Imazen.Test.Webp/Imazen.Test.Webp.csproj
+++ b/src/Imazen.Test.Webp/Imazen.Test.Webp.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.*" />
     <PackageReference Include="xunit" Version="2.*" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.*">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.*">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -25,7 +25,7 @@
 
   <!-- System.Drawing.Common for .NET Core tests on Windows -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="System.Drawing.Common" Version="8.*" />
+    <PackageReference Include="System.Drawing.Common" Version="10.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Imazen.WebP/Imazen.WebP.csproj
+++ b/src/Imazen.WebP/Imazen.WebP.csproj
@@ -18,7 +18,7 @@
 
   <!-- System.Drawing.Common for netstandard2.0 and net8.0 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="System.Drawing.Common" Version="8.*" />
+    <PackageReference Include="System.Drawing.Common" Version="10.*" />
   </ItemGroup>
 
   <!-- System.Runtime.InteropServices.RuntimeInformation for net472/net48 -->

--- a/src/Imazen.WebP/WebPEncoder.cs
+++ b/src/Imazen.WebP/WebPEncoder.cs
@@ -22,11 +22,17 @@ namespace Imazen.WebP
         {
             int size = (int)(uint)dataSize;
             if (size <= 0) return 1;
-            byte[] buffer = new byte[size];
-            Marshal.Copy(data, buffer, 0, size);
             var handle = GCHandle.FromIntPtr(picture.custom_ptr);
             var ctx = (EncodeOutput)handle.Target!;
+#if NETCOREAPP
+            unsafe {
+                ctx.Stream.Write(new ReadOnlySpan<byte>((void*)data, size));
+            }
+#else
+            byte[] buffer = new byte[size];
+            Marshal.Copy(data, buffer, 0, size);
             ctx.Stream.Write(buffer, 0, size);
+#endif
             return 1;
         }
 

--- a/src/Imazen.WebP/WebPEncoder.cs
+++ b/src/Imazen.WebP/WebPEncoder.cs
@@ -15,7 +15,7 @@ namespace Imazen.WebP
 
         private sealed class EncodeOutput(Stream stream)
         {
-            public Stream Stream = stream;
+            public readonly Stream Stream = stream;
         }
 
         private static int ManagedWriter(IntPtr data, UIntPtr dataSize, ref WebPPicture picture)

--- a/src/Imazen.WebP/WebPEncoder.cs
+++ b/src/Imazen.WebP/WebPEncoder.cs
@@ -11,11 +11,11 @@ namespace Imazen.WebP
     public static class WebPEncoder
     {
         // Prevent delegate from being GC'd during encoding
-        [ThreadStatic] private static WebPWriterFunction? _writerDelegate;
+        private static readonly WebPWriterFunction _writerDelegate = ManagedWriter;
 
-        private class EncodeOutput
+        private sealed class EncodeOutput(Stream stream)
         {
-            public MemoryStream Stream = new MemoryStream();
+            public Stream Stream = stream;
         }
 
         private static int ManagedWriter(IntPtr data, UIntPtr dataSize, ref WebPPicture picture)
@@ -170,10 +170,22 @@ namespace Imazen.WebP
         public static byte[] Encode(byte[] pixels, int width, int height, int stride,
             WebPPixelFormat format, WebPEncoderConfig config)
         {
+            var outputStream = new MemoryStream();
+            Encode(pixels, width, height, stride, format, config, outputStream);
+            return outputStream.ToArray();
+        }
+
+        /// <summary>
+        /// Encodes raw pixel data using advanced WebPEncoderConfig settings and writes to a stream.
+        /// </summary>
+        public static void Encode(byte[] pixels, int width, int height, int stride,
+            WebPPixelFormat format, WebPEncoderConfig config, Stream outputStream)
+        {
             if (pixels == null) throw new ArgumentNullException(nameof(pixels));
             if (config == null) throw new ArgumentNullException(nameof(config));
             if (width <= 0) throw new ArgumentOutOfRangeException(nameof(width));
             if (height <= 0) throw new ArgumentOutOfRangeException(nameof(height));
+            if (outputStream == null) throw new ArgumentNullException(nameof(outputStream));
 
             if (!config.Validate())
                 throw new ArgumentException("Invalid WebP encoder configuration", nameof(config));
@@ -193,10 +205,8 @@ namespace Imazen.WebP
             picture.use_argb = 1;
 
             var pixelHandle = GCHandle.Alloc(pixels, GCHandleType.Pinned);
-            var output = new EncodeOutput();
+            var output = new EncodeOutput(outputStream);
             var outputHandle = GCHandle.Alloc(output);
-            // Keep delegate alive during encoding
-            _writerDelegate = ManagedWriter;
             try
             {
                 IntPtr pixelPtr = pixelHandle.AddrOfPinnedObject();
@@ -233,8 +243,6 @@ namespace Imazen.WebP
 
                 if (encodeResult == 0)
                     throw new Exception($"WebP encode failed with error: {picture.error_code}");
-
-                return output.Stream.ToArray();
             }
             finally
             {
@@ -245,19 +253,7 @@ namespace Imazen.WebP
                 });
                 pixelHandle.Free();
                 outputHandle.Free();
-                _writerDelegate = null;
             }
-        }
-
-        /// <summary>
-        /// Encodes raw pixel data using advanced WebPEncoderConfig settings and writes to a stream.
-        /// </summary>
-        public static void Encode(byte[] pixels, int width, int height, int stride,
-            WebPPixelFormat format, WebPEncoderConfig config, Stream outputStream)
-        {
-            if (outputStream == null) throw new ArgumentNullException(nameof(outputStream));
-            byte[] encoded = Encode(pixels, width, height, stride, format, config);
-            outputStream.Write(encoded, 0, encoded.Length);
         }
     }
 }


### PR DESCRIPTION
Moved all the code from `Encode(..., config)` to `Encode(..., config, outputStream)`, so that it can write to the given stream directly instead of creating intermediate `MemoryStream` and `byte[]` array.

Removed unnecessary `byte[]` allocation inside `WebPEncoder.ManagedWriter` for `NETCOREAPP`.

Updated dependencies.